### PR TITLE
As fix rubocop schema

### DIFF
--- a/.rubocop_schema.49.yml
+++ b/.rubocop_schema.49.yml
@@ -1,6 +1,6 @@
 # Configuration for Rubocop >= 0.49.0
 
-Layout/AlignHash:
+Layout/HashAlignment:
   EnforcedColonStyle: 'key'
   EnforcedHashRocketStyle: 'key'
 

--- a/.rubocop_schema.49.yml
+++ b/.rubocop_schema.49.yml
@@ -1,6 +1,6 @@
 # Configuration for Rubocop >= 0.49.0
 
-Layout/HashAlignment:
+Layout/AlignHash:
   EnforcedColonStyle: 'key'
   EnforcedHashRocketStyle: 'key'
 

--- a/.rubocop_schema.53.yml
+++ b/.rubocop_schema.53.yml
@@ -1,6 +1,6 @@
 # Configuration for Rubocop >= 0.53.0
 
-Layout/AlignHash:
+Layout/HashAlignment:
   EnforcedColonStyle: 'key'
   EnforcedHashRocketStyle: 'key'
 


### PR DESCRIPTION
This fix is required for Rails version 6 and Rubocop 0.78 + 